### PR TITLE
Fix triggering custom warning click events on page load for radio view

### DIFF
--- a/addon-SV_WarningImprovements.xml
+++ b/addon-SV_WarningImprovements.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<addon addon_id="SV_WarningImprovements" title="Warning Improvements" version_string="1.4.6" version_id="1040600" url="https://xenforo.com/community/resources/warning-improvements-by-xon.4156/" install_callback_class="SV_WarningImprovements_Installer" install_callback_method="install" uninstall_callback_class="SV_WarningImprovements_Installer" uninstall_callback_method="uninstall">
+<addon addon_id="SV_WarningImprovements" title="Warning Improvements" version_string="1.4.7" version_id="1040700" url="https://xenforo.com/community/resources/warning-improvements-by-xon.4156/" install_callback_class="SV_WarningImprovements_Installer" install_callback_method="install" uninstall_callback_class="SV_WarningImprovements_Installer" uninstall_callback_method="uninstall">
   <admin_navigation/>
   <admin_permissions/>
   <admin_style_properties/>
@@ -767,7 +767,7 @@ New Thread trumps replying to a thread. Only the last warning action is applied 
 		</xen:if>
 	</div>
 </div>]]></template>
-    <template title="sv_warning_improvement_js" version_id="1040600" version_string="1.4.6"><![CDATA[<script>
+    <template title="sv_warning_improvement_js" version_id="1040700" version_string="1.4.7"><![CDATA[<script>
 !function($, window, document, _undefined)
 {
 	<xen:if is="{$xenOptions.sv_warningimprovements_continue_button}">
@@ -797,10 +797,13 @@ New Thread trumps replying to a thread. Only the last warning action is applied 
 	});
 	</xen:if>
 
+	XenForo.CustomWarningRadioTrigger = function ($input)
+	{
+		$input.trigger('click');
+	}
+	XenForo.register('input#customWarning', 'XenForo.CustomWarningRadioTrigger');
 	XenForo.WarningDefaultActionFormFillerControl = function($input)
 	{
-		$('input#customWarning').trigger('click');
-		
 		if ($input.val() == '{$xenOptions.sv_warningimprovements_default_content_action}') {
 			$input.trigger('click');
 		}


### PR DESCRIPTION
It wouldn't trigger if there was no warning action tab on the warn screen.

Fixes #17 