### PR TITLE
Fix potential error when an active warning action is deleted

### DIFF
--- a/upload/library/SV/WarningImprovements/XenForo/Model/Warning/Patch.php
+++ b/upload/library/SV/WarningImprovements/XenForo/Model/Warning/Patch.php
@@ -20,15 +20,15 @@ class SV_WarningImprovements_XenForo_Model_Warning_Patch extends XFCP_SV_Warning
 
         foreach ($actions as $action)
         {
-            $warningCategoryId = $action['sv_warning_category_id'];
+            $points = array(
+                'old' => $oldPoints,
+                'new' => $newPoints
+            );
 
-            if (isset($warningPoints[$warningCategoryId]))
+            $warningCategoryId = $action['sv_warning_category_id'];
+            if (!empty($warningPoints[$warningCategoryId]))
             {
                 $points = $warningPoints[$warningCategoryId];
-            }
-            else
-            {
-                $points = array('old' => $oldPoints, 'new' => $newPoints);
             }
 
             if ($action['points'] <= $points['old'])
@@ -57,25 +57,29 @@ class SV_WarningImprovements_XenForo_Model_Warning_Patch extends XFCP_SV_Warning
             return;
         }
 
-        $warningPoints = $this->getCategoryWarningPointsByUser($userId);
         $warningActions = $this->getWarningActions();
+        $warningPoints = $this->getCategoryWarningPointsByUser($userId);
 
         $db = $this->_getDb();
         XenForo_Db::beginTransaction($db);
 
         foreach ($triggers as $trigger)
         {
-            $warningActionId = $trigger['warning_action_id'];
-            $warningAction = $warningActions[$warningActionId];
-            $warningCategoryId = $warningAction['sv_warning_category_id'];
+            $points = array(
+                'old' => $oldPoints,
+                'new' => $newPoints
+            );
 
-            if (isset($warningPoints[$warningCategoryId]))
+            $warningActionId = $trigger['warning_action_id'];
+            if (!empty($warningActions[$warningActionId]))
             {
-                $points = $warningPoints[$warningCategoryId];
-            }
-            else
-            {
-                $points = array('old' => $oldPoints, 'new' => $newPoints);
+                $warningAction = $warningActions[$warningActionId];
+
+                $warningCategoryId = $warningAction['sv_warning_category_id'];
+                if (!empty($warningPoints[$warningCategoryId]))
+                {
+                    $points = $warningPoints[$warningCategoryId];
+                }
             }
 
             if ($trigger['trigger_points'] > $points['new'])


### PR DESCRIPTION
This can cause the trigger to error when attempting to match it with an action so that its category points may be checked.

Fortunately, this bug shouldn't cause any database corruption or inconsistencies as it would throw an error and cause the transaction to be rolled back (and retried next time the expiry cron entry is run).